### PR TITLE
fix the usage of the dotenv command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This Streamlit app guides users through lessons using a chat-based interface. To
 
    If using `dotenv` to manage environment variables, use the following command:
    ```
-   dotenv streamlit run lc_main.py
+   dotenv run -- streamlit run lc_main.py
    ```
    
 ## Additional Files and Branches


### PR DESCRIPTION
When I use dotenv to start the program with streamlit, I get an error, and the message is as follows:

```sh
dotenv streamlit run lc_main.py
Usage: dotenv [OPTIONS] COMMAND [ARGS]...
Try 'dotenv --help' for help.

Error: No such command 'streamlit'.
```

I found through the dotenv documentation that it can only be executed properly with the run command, so I submitted this PR.

```sh
dotenv run -- streamlit run lc_main.py
```